### PR TITLE
6 rolling update and pod distruption budget refs ap 1705

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1-rc1
+version: 0.3.2-rc1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.0-rc1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0-rc1
+version: 0.3.1-rc1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2-rc1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/README.md
+++ b/README.md
@@ -1,26 +1,34 @@
 # Helmchart for generic python application
 
-[![Packahe Helm Chart](https://github.com/zcsadmin/ml-pyhchart-helmchart/actions/workflows/helm-package.yml/badge.svg)](https://github.com/zcsadmin/ml-pyhchart-helmchart/actions/workflows/helm-package.yml)
+[![Package Helm Chart](https://github.com/zcsadmin/ml-pyhchart-helmchart/actions/workflows/helm-package.yml/badge.svg)](https://github.com/zcsadmin/ml-pyhchart-helmchart/actions/workflows/helm-package.yml)
 
 [![Push Helm Chart to Artifact Registry](https://github.com/zcsadmin/ml-pyhchart-helmchart/actions/workflows/helm-push.yml/badge.svg)](https://github.com/zcsadmin/ml-pyhchart-helmchart/actions/workflows/helm-push.yml)
 
-
 ## Changelog
 
-### 0.3.0
-Set rolling update strategy, pod distruption budget and replicaCount to 3 for production environments.
-For Sandbox and Development environments we must set replicaCount in values.yaml to 1 and pdb.enabled to false. 
+### 0.3.3
 
-### 0.2.2 
+Set rolling update strategy, pod disruption budget and replicaCount to 1.
+
+### 0.3.0
+
+Set rolling update strategy, pod disruption budget and replicaCount to 3 for production environments.
+For Sandbox and Development environments we must set replicaCount in values.yaml to 1 and pdb.enabled to false.
+
+### 0.2.2
+
 Set container name for deployment.
 
 ### 0.2.1
+
 Enhance secrets support.
 
 ### 0.2.0
+
 Add support for secret values.
 
 ### 0.1.0
+
 Initial chart release.
 
 ## Artifact Repository
@@ -28,6 +36,7 @@ Initial chart release.
 `oci://europe-west1-docker.pkg.dev/ai-accounting-405809/ml-helm-charts/pyhchart`
 
 List docker images from cli:
+
 ```bash
 gcloud artifacts docker images list europe-west1-docker.pkg.dev/ai-accounting-405809/ml-helm-charts
 ```
@@ -37,10 +46,11 @@ gcloud artifacts docker images list europe-west1-docker.pkg.dev/ai-accounting-40
 You need to download the chart locally and `appVersion` value in `Chart.yaml` file.
 Also, you need a `values-app.yaml` file with the specific values for your application.
 Then, you can install the application with the following command:
+
 ```bash
 helm install YOUR_APP -f values-app.yaml .
 ```
 
 ## Useful links
 
- - [Artifact repository](https://console.cloud.google.com/artifacts/docker/ai-accounting-405809/europe-west1/ml-helm-charts/pyhchart?project=ai-accounting-405809)
+- [Artifact repository](https://console.cloud.google.com/artifacts/docker/ai-accounting-405809/europe-west1/ml-helm-charts/pyhchart?project=ai-accounting-405809)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 ## Changelog
 
+### 0.3.0
+Set rolling update strategy, pod distruption budget and replicaCount to 3 for production environments.
+For Sandbox and Development environments we must set replicaCount in values.yaml to 1 and pdb.enabled to false. 
+
 ### 0.2.2 
 Set container name for deployment.
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,6 +9,11 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable | default 1 }}
+      maxSurge: {{ .Values.rollingUpdate.maxSurge | default 1 }}
   selector:
     matchLabels:
       {{- include "pyhchart.selectorLabels" . | nindent 6 }}

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "pyhchart.fullname" . }}-pdb
   namespace: {{ include "common.names.namespace" . | quote }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable | default 2 }}
   selector:
     matchLabels:
       {{- include "pyhchart.selectorLabels" . | nindent 6 }}

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pyhchart.fullname" . }}-pdb
+  namespace: {{ include "common.names.namespace" . | quote }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "pyhchart.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -2,16 +2,19 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 3
+replicaCount: 1
 
+# https://www.baeldung.com/ops/deployment-rollout-kubernetes
+# https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
 rollingUpdate:
-  maxUnavailable: 1
-  maxSurge: 1
+  maxUnavailable: 25%
+  maxSurge: 25%
 
-# for 
+# https://www.baeldung.com/ops/kubernetes-pod-disruption-budget
+# https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 pdb:
   enabled: true
-  minAvailable: 2
+  minAvailable: 1
 
 image:
   repository: 

--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ rollingUpdate:
 # for 
 pdb:
   enabled: true
-  minAvailable: 1
+  minAvailable: 2
 
 image:
   repository: 

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,16 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 3
+
+rollingUpdate:
+  maxUnavailable: 1
+  maxSurge: 1
+
+# for 
+pdb:
+  enabled: true
+  minAvailable: 1
 
 image:
   repository: 


### PR DESCRIPTION
- **feat: Set rolling update strategy, pod distruption budget and replicaCount to 3 for production environments**
- **fix: fix chart version**
- **chore: change pod distruption budget default minAvailable value to 2**
- **fix: fix pod distruption budget default minAvailable value to 2**
- **chore: deploy final version 0.3.2**
- **feat: update default values**
